### PR TITLE
changes to get vizstorm working out-of-the-box

### DIFF
--- a/scripts/fetch/utils.R
+++ b/scripts/fetch/utils.R
@@ -79,7 +79,7 @@ plot_viewbox_limits <- function(geo, ...){
     stop("only tested with sfc objects.")
   }
   usr <- par('usr')
-  svg_viewbox <- xml_attr(xml2::read_xml(.fun()[1]), 'viewBox')
+  svg_viewbox <- xml2::xml_attr(xml2::read_xml(.fun()[1]), 'viewBox')
   dev.off()
   
   viewbox <- bbox_to_polygon(usr[c(1, 3, 2, 4)], bbox_crs = sf::st_crs(geo))

--- a/viz.yaml
+++ b/viz.yaml
@@ -229,4 +229,16 @@ visualize:
     scripts: ["scripts/visualize/svg_skeleton.R"]
     reader: svg
     mimetype: image/svg+xml
+    title: "SVG skeleton"
+    alttext: "Beginning of the full storm SVG"
 publish:
+  -
+    id: vizstorm_page
+    name: index
+    template: fullpage
+    publisher: page
+    depends: 
+      storm_figure: "svg_skeleton"
+    context:
+      resources: 
+      sections: "storm_figure"


### PR DESCRIPTION
The `xml2::` addition was because it failed using regular `make`. I did that before I realized I needed the remake version of vizlab. I'm not sure if it is necessary with remake, but doesn't hurt to be explicit.

I wanted to have the target directory, so that I could inspect the image, so I added a rough version of what the fullpage might look like.