### PR TITLE
d3 add precip cells for one timestep

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -64,9 +64,7 @@ function createMap() {
         .data(state_data.features)
         .enter()
         .append('path')
-        .attr('d', path)
-        .attr('fill', "#9a9a9a")
-        .attr('stroke', 'none');
+        .attr('d', path);
   
   // add counties
   map.append("g").attr('id', 'countypolygons')
@@ -75,9 +73,6 @@ function createMap() {
         .enter()
         .append('path')
         .attr('d', path)
-        .attr('fill', "#efefef")
-        .attr('stroke', '#c6c6c6')
-        .attr('stroke-width', 0.5)
         .on("mouseover", mouseover)
         .on("mouseout", mouseout);
     
@@ -87,11 +82,7 @@ function createMap() {
         .data(state_data.features)
         .enter()
         .append('path')
-        .attr('d', path)
-        .attr("pointer-events", "none") // pointer events passed to county layer
-        .attr('fill', "none")
-        .attr('stroke', '#5f5f5f')
-        .attr('stroke-width', 0.5);
+        .attr('d', path); // pointer events passed to county layer
   
   // add precip cells on top of everything else
   map.append("g").attr('id', 'precipcells')
@@ -100,7 +91,6 @@ function createMap() {
         .enter()
         .append('path')
         .attr('d', path)
-        .attr("pointer-events", "none") // pointer events passed to county layer
         .attr('fill', function(d) { 
           d.precip = precip.get(d.properties.ID); //use "get" to grab precip from the match ID
           if(d.precip > 0) { //need if statement, adding "transparent" to array did not work
@@ -108,10 +98,7 @@ function createMap() {
           } else {
             return "transparent";
           } 
-        })
-        .attr('stroke', 'none')
-        .attr("opacity", "0.7");
-
+        });
 }
 
 function mouseover(d) {
@@ -121,11 +108,8 @@ function mouseover(d) {
 	
 	d3.select(".tooltip")
 		.style("display", "block")
-		.style("position", "absolute")
 		.style("left", x_val+"px")
 		.style("top", (y_val-y_buffer)+"px")
-		.style("text-anchor", "end")
-		.style("text-transform", "capitalize")
 		.text(formatCountyName(d.properties.ID));
   
   d3.select(this).style('fill', 'orange'); 

--- a/js/map.js
+++ b/js/map.js
@@ -33,11 +33,9 @@ var div = d3.select("body")
 var precip = d3.map();
 
 // precip color scale
-var color_vals = d3.schemeBlues[9];
-color_vals.unshift("transparent"); //add to front of color array
 var color = d3.scaleThreshold()
     .domain(d3.range(0, 10)) // need better way to get range of data, should do inside queue
-    .range(color_vals);
+    .range(d3.schemeBlues[9]);
 
 // Add map features, need to queue to load more than one json
 d3.queue()
@@ -91,7 +89,7 @@ function createMap() {
         .append('path')
         .attr('d', path)
         .attr("pointer-events", "none") // pointer events passed to county layer
-        .attr('fill', "transparent")
+        .attr('fill', "none")
         .attr('stroke', '#5f5f5f')
         .attr('stroke-width', 0.5);
   
@@ -105,7 +103,11 @@ function createMap() {
         .attr("pointer-events", "none") // pointer events passed to county layer
         .attr('fill', function(d) { 
           d.precip = precip.get(d.properties.ID); //use "get" to grab precip from the match ID
-          return color(d.precip); 
+          if(d.precip > 0) { //need if statement, adding "transparent" to array did not work
+            return color(d.precip); 
+          } else {
+            return "transparent";
+          } 
         })
         .attr('stroke', 'none')
         .attr("opacity", "0.7");

--- a/layout/css/map.css
+++ b/layout/css/map.css
@@ -1,0 +1,34 @@
+#statepolygons path,
+#statepolygons line {
+  fill: #9a9a9a;
+  stroke: none;
+  stroke-width: 2;
+}
+
+#countypolygons path,
+#countypolygons line {
+  fill: #efefef;
+  stroke: #c6c6c6;
+  stroke-width: 0.5;
+}
+
+#stateoutline path,
+#stateoutline line {
+  fill: none;
+  stroke: #5f5f5f;
+  stroke-width: 0.5;
+  pointer-events: none; /* pointer events passed to layer below*/
+}
+
+#precipcells path,
+#precipcells line {
+  stroke: none;
+  opacity: 0.7;
+  pointer-events: none; /* pointer events passed to layer below*/
+}
+
+.tooltip {
+  position: absolute;
+  text-anchor: end;
+  text-transform: capitalize;
+}

--- a/scripts/fetch/precip_cell_data.R
+++ b/scripts/fetch/precip_cell_data.R
@@ -24,7 +24,14 @@ fetch.stageiv_precip_gdp <- function(viz){
   job <- geoknife::geoknife(stencil, fabric, wait = TRUE, REQUIRE_FULL_COVERAGE=FALSE)
   
   data <- geoknife::result(job, with.units = TRUE)
-  saveRDS(data, file = viz[['location']])
+  
+  tidy_data <- tidyr::gather(data, key = "cell", value = "precip", 
+                             -c(DateTime, variable, statistic, units))
+  
+  #force into one timestep for now...animation of multiple will come later
+  tidy_data_t <- dplyr::filter(tidy_data, DateTime == "2014-01-02 12:00:00")
+  
+  write.csv(tidy_data_t, file = viz[['location']], row.names=FALSE)
 }
 
 fetchTimestamp.stageiv_precip_gdp <- vizlab::alwaysCurrent

--- a/viz.yaml
+++ b/viz.yaml
@@ -177,6 +177,10 @@ publish:
     location: "js/map.js"
     mimetype: application/javascript
   -
+    id: map_css
+    location: "layout/css/map.css"
+    mimetype: text/css
+  -
     id: vizstorm_page
     name: index
     template: fullpage
@@ -185,7 +189,8 @@ publish:
       lib_d3_js: "lib-d3-js"
       lib_d3_scale_js: "lib-d3-scale-js"
       map_js: "map_js"
+      map_css: "map_css"
     context:
-      resources: ["lib_d3_js", "lib_d3_scale_js"]
+      resources: ["lib_d3_js", "lib_d3_scale_js", "map_css"]
       sections: ["map_js"]
       

--- a/viz.yaml
+++ b/viz.yaml
@@ -16,9 +16,9 @@ info:
   required-packages:
     vizlab:
       repo: github
-      version: 0.2.2.9003
+      version: 0.2.2.9008
       name: USGS-VIZLAB/vizlab
-      ref: v0.2.2.9003
+      ref: v0.2.2.9008
     dplyr:
       repo: CRAN
       version: 0.5.0

--- a/viz.yaml
+++ b/viz.yaml
@@ -81,8 +81,8 @@ fetch:
     depends: viewbox_limits
   -
     id: precip_cell_data
-    location: cache/precip_cell_data.rds
-    reader: rds
+    location: cache/precip_cell_data.csv
+    reader: csv
     fetcher: stageiv_precip_gdp
     scripts: scripts/fetch/precip_cell_data.R
     depends: 
@@ -124,11 +124,11 @@ process:
     id: precip_cells
     location: cache/precip_cells.rds
     reader: rds
-    cell_size: 80000
+    cell_size: 0.3
     processor: cells_from_mask
     scripts: [scripts/process/cells_from_mask.R]
     depends: 
-      mask_poly: "state_map_data"
+      mask_poly: "county_map_data"
   - 
     id: precip_cells_geojson
     location: cache/precip_cells.geojson
@@ -182,9 +182,10 @@ publish:
     template: fullpage
     publisher: page
     depends: 
-      lib-d3-js: lib-d3-js
+      lib_d3_js: "lib-d3-js"
+      lib_d3_scale_js: "lib-d3-scale-js"
       map_js: "map_js"
     context:
-      resources: ["lib-d3-js"]
+      resources: ["lib_d3_js", "lib_d3_scale_js"]
       sections: ["map_js"]
       


### PR DESCRIPTION
You can still hover over counties below the precip cells. Not sure if this is weird behavior or not, but I can easily turn it off by setting "pointer-events". Only doing one timestep right now. Animations through time is the next hurdle :)

![state_map_hovers](https://user-images.githubusercontent.com/13220910/34745830-70d9381a-f557-11e7-9857-cf69da63ce3a.gif)

This requires vizlab v0.2.2.9008 a la https://github.com/USGS-VIZLAB/vizlab/pull/326
  