### PR TITLE
use geoAlbers (#36)

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -3,9 +3,10 @@ var chart_width     =   1000;
 var chart_height    =   600;
 
 // Projection
-var projection = d3.geoMercator() //changing to geoAlbers makes the map disappear
-    .scale(1500)
-    .center([-91.34397, 32.25196])
+var projection = d3.geoAlbers()
+    .scale([1800])
+    // default is .rotate([96,0]) to center on US
+    .center([96-91.34397, 32.25196]) // adjust longitude relative to rotation
     .translate([chart_width / 2, chart_height / 2]);
 var path = d3.geoPath()
     .projection(projection);

--- a/viz.yaml
+++ b/viz.yaml
@@ -48,7 +48,7 @@ info:
 parameter:
   -
     id: spatial_metadata
-    crs: '+init=epsg:4326' # works with d3.geoMercator
+    crs: '+init=epsg:4326' # works with d3.geoAlbers
     bbox: [-87, 17, -70, 34]
   -
     id: plot_metadata


### PR DESCRIPTION
Resolves the problem with projecting in d3.geoAlbers from #36. See notes in that issue for explanation.

![image](https://user-images.githubusercontent.com/12039957/34908616-d25678e6-f84f-11e7-9713-162af757381c.png)

```js
// Projection
var projection = d3.geoAlbers()
    .scale([1800])
    // default is .rotate([96,0]) to center on US
    .center([96-91.34397, 32.25196]) // adjust longitude relative to rotation
    .translate([chart_width / 2, chart_height / 2]);
```